### PR TITLE
Add laudo form and AI integration

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,26 @@
 import React, { useState, useEffect } from 'react';
 import Login from './Login';
 import AudioRecorder from './components/AudioRecorder';
+import LaudoForm from './components/LaudoForm';
+import api from './api';
 
 function App() {
   // Controla se o usuário está autenticado. Ao carregar o componente, verifica
   // se existe um token salvo no localStorage. Após o login, definimos
   // isAuthenticated como true, exibindo as funcionalidades do sistema.
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [laudoData, setLaudoData] = useState({});
+
+  const handleSave = async () => {
+    try {
+      await api.post('/laudos', laudoData);
+      alert('Laudo salvo com sucesso');
+      setLaudoData({});
+    } catch (err) {
+      console.error('Erro ao salvar laudo', err);
+      alert('Erro ao salvar laudo');
+    }
+  };
 
   useEffect(() => {
     // Ao montar, verifica se há token armazenado
@@ -22,8 +36,8 @@ function App() {
       {isAuthenticated ? (
         // Conteúdo exibido após autenticação
         <>
-          {/* Aqui serão inseridos outros componentes protegidos, como o formulário e lista de laudos */}
-          <AudioRecorder />
+          <AudioRecorder onParsed={(data) => setLaudoData(data)} />
+          <LaudoForm data={laudoData} onChange={setLaudoData} onSave={handleSave} />
         </>
       ) : (
         // Exibe tela de login. Ao autenticar com sucesso, atualiza o estado.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -9,9 +9,14 @@ const api = axios.create({
   baseURL: BASE_URL,
 });
 
-// Interceptor para debug
+// Adiciona token JWT se estiver salvo em localStorage
 api.interceptors.request.use(
   (config) => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     console.log('Request:', config.method?.toUpperCase(), config.url);
     return config;
   },
@@ -20,6 +25,8 @@ api.interceptors.request.use(
     return Promise.reject(error);
   }
 );
+
+// Interceptor de resposta apenas para log
 
 api.interceptors.response.use(
   (response) => {

--- a/frontend/src/components/AudioRecorder.js
+++ b/frontend/src/components/AudioRecorder.js
@@ -11,7 +11,8 @@ import api from '../api';
  * arquivo gravado ao backend através de um POST em `/upload-audio`.
  * Se a gravação ou o upload falharem, mensagens de erro são exibidas.
  */
-function AudioRecorder() {
+// `onParsed` recebe os campos interpretados do backend
+function AudioRecorder({ onParsed }) {
   const [isRecording, setIsRecording] = useState(false);
   const [message, setMessage] = useState('');
   const mediaRecorderRef = useRef(null);
@@ -55,7 +56,17 @@ function AudioRecorder() {
           'Content-Type': 'multipart/form-data',
         },
       });
-      setMessage(`Transcrição: ${res.data.transcription}`);
+      const transcription = res.data.transcription;
+      setMessage(`Transcrição: ${transcription}`);
+
+      // Envia a transcrição para o endpoint de parsing
+      const parseRes = await api.post('/parse-laudo', {
+        transcription,
+      });
+
+      if (typeof onParsed === 'function') {
+        onParsed(parseRes.data);
+      }
     } catch (err) {
       console.error(err);
       setMessage('Erro ao enviar áudio para o servidor');

--- a/frontend/src/components/LaudoForm.js
+++ b/frontend/src/components/LaudoForm.js
@@ -1,11 +1,71 @@
 import React from 'react';
 
-function LaudoForm() {
+/**
+ * Formulário para edição dos campos do laudo.
+ * Recebe `data` com os valores atuais, `onChange` para atualizar
+ * o estado no componente pai e `onSave` para persistir no backend.
+ */
+function LaudoForm({ data, onChange, onSave }) {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    if (typeof onChange === 'function') {
+      onChange({ ...data, [name]: value });
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (typeof onSave === 'function') {
+      onSave();
+    }
+  };
+
   return (
-    <div>
-      {/* TODO: implementar campos do formulário de laudo */}
-      <p>Laudo form placeholder</p>
-    </div>
+    <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Cliente:
+          <input
+            type="text"
+            name="cliente"
+            value={data.cliente || ''}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Equipamento:
+          <input
+            type="text"
+            name="equipamento"
+            value={data.equipamento || ''}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Diagnóstico:
+          <textarea
+            name="diagnostico"
+            value={data.diagnostico || ''}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <label>
+          Solução:
+          <textarea
+            name="solucao"
+            value={data.solucao || ''}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <button type="submit">Salvar Laudo</button>
+    </form>
   );
 }
 


### PR DESCRIPTION
## Summary
- implement JWT header in API client
- extend audio recorder to parse laudo via backend
- add basic laudo form component
- wire recorder and form in the main app
- extend backend model and integrate with OpenAI Whisper & ChatGPT

## Testing
- `python3 -m py_compile backend/app.py`
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68857b873dbc832486a04705a4776f11